### PR TITLE
Print a nice message when an unknown feature name is given to describe-genome.py

### DIFF
--- a/bin/describe-feature.py
+++ b/bin/describe-feature.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from dark.fasta import FastaReads
 
 from gb2seq.alignment import Gb2Alignment, addAlignerOption
-from gb2seq.features import Features, addFeatureOptions
+from gb2seq.features import Features, addFeatureOptions, UnknownFeatureNameError
 from gb2seq.sars2 import SARS_COV_2_ALIASES
 
 
@@ -136,7 +136,7 @@ def main(args):
         for name in args.name:
             try:
                 wantedNames.append(features.canonicalName(name))
-            except KeyError:
+            except UnknownFeatureNameError:
                 forgot = (
                     " It looks like you forgot to use --sars2."
                     if name.lower() in SARS_COV_2_ALIASES

--- a/bin/describe-site.py
+++ b/bin/describe-site.py
@@ -28,7 +28,7 @@ def report(genome, args, includeGenome=True):
             args.site - 1,
             relativeToFeature=args.relativeToFeature,
             aa=args.aa,
-            featureName=args.feature,
+            featureName=args.featureName,
             includeUntranslated=args.includeUntranslated,
             minReferenceCoverage=args.minReferenceCoverage,
         )
@@ -126,11 +126,11 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--feature",
+        "--featureName",
         metavar="FEATURE",
         help=(
-            "The feature to examine (e.g., nsp2). This is required if you "
-            "use --aa or --relativeToFeature"
+            "The name of the feature to examine (e.g., nsp2). This is required "
+            "if you use --aa or --relativeToFeature"
         ),
     )
 

--- a/gb2seq/__init__.py
+++ b/gb2seq/__init__.py
@@ -2,4 +2,4 @@ class Gb2SeqError(Exception):
     "A gb2seq library error occurred."
 
 
-__version__ = "0.2.20"
+__version__ = "0.2.21"

--- a/gb2seq/alignment.py
+++ b/gb2seq/alignment.py
@@ -8,7 +8,7 @@ from dark.reads import AARead, DNARead, Reads
 
 from gb2seq import Gb2SeqError
 from gb2seq.change import splitChange
-from gb2seq.features import Features
+from gb2seq.features import Features, UnknownFeatureNameError
 from gb2seq.translate import (
     translate,
     translateSARS2Spike,
@@ -291,6 +291,7 @@ class Gb2Alignment:
             sequences.
         @param raiseOnReferenceGaps: A C{bool}. If C{True} and the aligner
             suggests a gap in the reference, raise a ReferenceInsertionError.
+        @raise UnknownFeatureNameError: If C{featureName} is unknown.
         @raise AssertionError: If the aligned reference and genome sequences
             are not the same length.
         @raise ReferenceInsertionError: (as above for raiseOnReferenceGaps).
@@ -305,7 +306,11 @@ class Gb2Alignment:
         except KeyError:
             pass
 
-        feature = self.features[featureName]
+        try:
+            feature = self.features[featureName]
+        except KeyError:
+            raise UnknownFeatureNameError(featureName)
+
         name = feature["name"]
         length = feature["stop"] - feature["start"]
         # 'offset' is the offset in the (possibly gapped) alignment.
@@ -535,7 +540,7 @@ class Gb2Alignment:
             case an error message will be printed to C{errFp}.
         @param errFp: An open file pointer to write error messages to, if any.
             Only used if C{onError} is 'print'.
-        @raise IndexError: If the offset is out of range.
+        @raise IndexError: If the offset is out of range and C{onError} is "raise".
         @return: A C{list} containing a C{bool} indicating whether the read
             sequence has C{base} at C{offset} (or C{True} if C{base} is
             C{None}) and the C{str} base found at the offset. If there is an
@@ -791,7 +796,7 @@ class Gb2Alignment:
             are found for the offset and no feature name is given to
             disambiguate. Instead, use the first feature name returned by
             C{getFeatureNames}.
-        @raise KeyError: If the feature name is unknown.
+        @raise UnknownFeatureNameError: If C{featureName} is unknown.
         @raise ValueError: If incorrect arguments are passed (see below).
         @raise AmbiguousFeatureError: If multiple features occur at the offset
             and C{featureName} does not indicate the one to use.

--- a/gb2seq/features.py
+++ b/gb2seq/features.py
@@ -43,6 +43,10 @@ class AmbiguousFeatureError(Gb2SeqError):
     "More than one feature is referred to by an offset."
 
 
+class UnknownFeatureNameError(Gb2SeqError):
+    "A feature name is unknown."
+
+
 class Features(UserDict):
     """
     Manage sequence features.
@@ -107,8 +111,8 @@ class Features(UserDict):
                 )
             path = Path(referenceSpecification)
             if path.exists():
-                # A file argument can either be in GenBank format or
-                # contain a JSON object (the saved output of annotate-genome.py).
+                # A file argument can either be in GenBank format or contain a JSON
+                # object (the saved output of annotate-genome.py).
                 jsonError = seqError = None
                 with open(path) as fp:
                     try:
@@ -410,7 +414,7 @@ class Features(UserDict):
 
 
         @param name: A C{str} feature name to look up.
-        @raise KeyError: If the name is unknown.
+        @raise UnknownFeatureNameError: If the feature name is unknown.
         @return: A C{dict} for the feature, as above.
         """
         return self.data[self.canonicalName(name)]
@@ -420,8 +424,8 @@ class Features(UserDict):
         Get the canonical name for a feature.
 
         @param name: A C{str} feature name to look up.
-        @raise KeyError: If the name is unknown.
-        @return: A C{str} canonical name.
+        @raise UnknownFeatureNameError: If C{name} is not a known feature name.
+        @return: A C{str} canonical feature name.
         """
         if name in self:
             return name
@@ -433,7 +437,7 @@ class Features(UserDict):
 
         alias = self.aliasDict.get(nameLower)
         if alias is None:
-            raise KeyError(name)
+            raise UnknownFeatureNameError(name)
         else:
             assert alias in self
             return alias
@@ -456,7 +460,7 @@ class Features(UserDict):
         """
         try:
             canonicalName = self.canonicalName(name)
-        except KeyError:
+        except UnknownFeatureNameError:
             return set()
 
         result = {canonicalName}
@@ -496,7 +500,7 @@ class Features(UserDict):
         @param offset: An C{int} offset into the feature.
         @param aa: If C{True}, the offset is a number of amino acids, else a
             number of nucleotides.
-        @raise KeyError: If the name is unknown.
+        @raise UnknownFeatureNameError: If the name is unknown.
         @return: An C{int} nucleotide offset into the reference genome.
         """
         return self[name]["start"] + offset * (3 if aa else 1)
@@ -544,6 +548,8 @@ class Features(UserDict):
             the given C{offset} or if there are no features at the offset.
         @raise AmbiguousFeatureError: if there are multiple features at the
             offset and a feature name is not given.
+        @raise UnknownFeatureNameError: If the feature name is unknown (can be raised
+            via the call to self.canonicalName)
         @return: A 2-tuple, containing 1) a features C{dict} (as returned by
             __getitem__), if the requested feature is among those present at
             the offset, and 2) the set of all C{str} feature names present at

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from dark.reads import DNARead
 
-from gb2seq.features import Features
+from gb2seq.features import Features, UnknownFeatureNameError
 
 _FEATURES = Features(sars2=True)
 
@@ -47,9 +47,11 @@ class TestFeatures(TestCase):
 
     def testUnknownFeature(self):
         """
-        If an unknown feature is asked for, a KeyError must be raised.
+        If an unknown feature is asked for, an UnknownFeatureNameError must be raised.
         """
-        self.assertRaisesRegex(KeyError, "^'xx'$", _FEATURES.__getitem__, "xx")
+        self.assertRaisesRegex(
+            UnknownFeatureNameError, "^xx$", _FEATURES.__getitem__, "xx"
+        )
 
     def testPassingDict(self):
         """
@@ -123,10 +125,12 @@ class TestFeatures(TestCase):
 
     def testOffsetInUnknownFeature(self):
         """
-        If a genome offset for an unknown feature is requested, a KeyError
-        must be raised.
+        If a genome offset for an unknown feature is requested, an
+        UnknownFeatureNameError must be raised.
         """
-        self.assertRaisesRegex(KeyError, "^'xx'$", _FEATURES.referenceOffset, "xx", 10)
+        self.assertRaisesRegex(
+            UnknownFeatureNameError, "^xx$", _FEATURES.referenceOffset, "xx", 10
+        )
 
     def testAaOffsetInMembrane(self):
         """


### PR DESCRIPTION
Added a nice error message for when an unknown feature name is given to describe-genome.py. Added `UnknownFeatureNameError` exception and tried to make all code looking up features use it.

Fixes #4 
