### PR TITLE
Improved the Gb2Alignment.offsetInfo method to be more careful about the nt offset it returns in the genome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0 August 13, 2025
+
+Improved the `Gb2Alignment.offsetInfo` method to be more careful about the nt
+offset it returns in the genome (it was possible for it to return an index
+that was longer than the genome). The 'aa', 'ntOffset' values may now come
+back as `None`. See the long comment in that method for details on what it
+returns.
+
 ## 0.2.27 August 12, 2025
 
 Marked the SARS-CoV-2 furin cleavage site as a translated feature and an "fcs"

--- a/gb2seq/__init__.py
+++ b/gb2seq/__init__.py
@@ -2,4 +2,4 @@ class Gb2SeqError(Exception):
     "A gb2seq library error occurred."
 
 
-__version__ = "0.2.27"
+__version__ = "0.3.0"


### PR DESCRIPTION
It was possible for it to return an index that was longer than the genome. The 'aa' and 'ntOffset' values may now come back as `None`.